### PR TITLE
Updated files and documentation for iOS 18 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ $ bazel build //app
 $ bazel test $(bazel query 'kind(ios_unit_test,//...)')
 ```
 
+If the tests fail, run ` xcrun simctl list devices` to check what devices and OS versions are locally available. iOS version is set in [`shared.bzl`](/tools/shared.bzl) and device type and version is set in each test's [`BUILD.bazel`](/modules/API/API/API.swift) file.
+
 ## Underlying Tools
 
 - [`rules_apple`](https://github.com/bazelbuild/rules_apple)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ bazel build //app
 $ bazel test $(bazel query 'kind(ios_unit_test,//...)')
 ```
 
-If the tests fail, run ` xcrun simctl list devices` to check what devices and OS versions are locally available. iOS version is set in [`shared.bzl`](/tools/shared.bzl) and device type and version is set in each test's [`BUILD.bazel`](/modules/API/API/API.swift) file.
+If the tests fail, run `xcrun simctl list devices` to check what devices and OS versions are locally available. iOS version is set in [`shared.bzl`](/tools/shared.bzl).
 
 ## Underlying Tools
 

--- a/modules/API/BUILD.bazel
+++ b/modules/API/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
-load("//tools:shared.bzl", "versions")
+load("//tools:shared.bzl", "default_test_runner", "versions")
 
 # Code
 
@@ -31,16 +30,10 @@ swift_library(
     ],
 )
 
-ios_test_runner(
-    name = "IPHONE_16",
-    device_type = "iPhone 16",
-    os_version = versions.minimum_ios_version,
-)
-
 ios_unit_test(
     name = "APITests",
     minimum_os_version = versions.minimum_ios_version,
     visibility = ["//modules:default_test_visibility"],
     deps = [":APITestsLib"],
-    runner = "IPHONE_16",
+    runner = default_test_runner,
 )

--- a/modules/API/BUILD.bazel
+++ b/modules/API/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("//tools:shared.bzl", "versions")
 
 # Code
@@ -30,9 +31,16 @@ swift_library(
     ],
 )
 
+ios_test_runner(
+    name = "IPHONE_16",
+    device_type = "iPhone 16",
+    os_version = versions.minimum_ios_version,
+)
+
 ios_unit_test(
     name = "APITests",
     minimum_os_version = versions.minimum_ios_version,
     visibility = ["//modules:default_test_visibility"],
     deps = [":APITestsLib"],
+    runner = "IPHONE_16",
 )

--- a/modules/Models/BUILD.bazel
+++ b/modules/Models/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
-load("//tools:shared.bzl", "versions")
+load("//tools:shared.bzl", "default_test_runner", "versions")
 
 # Code
 
@@ -28,16 +27,10 @@ swift_library(
     ],
 )
 
-ios_test_runner(
-    name = "IPHONE_16",
-    device_type = "iPhone 16",
-    os_version = versions.minimum_ios_version,
-)
-
 ios_unit_test(
     name = "ModelsTests",
     minimum_os_version = versions.minimum_ios_version,
     visibility = ["//modules:default_test_visibility"],
     deps = [":ModelsTestsLib"],
-    runner = "IPHONE_16",
+    runner = default_test_runner,
 )

--- a/modules/Models/BUILD.bazel
+++ b/modules/Models/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("//tools:shared.bzl", "versions")
 
 # Code

--- a/modules/Models/BUILD.bazel
+++ b/modules/Models/BUILD.bazel
@@ -27,9 +27,16 @@ swift_library(
     ],
 )
 
+ios_test_runner(
+    name = "IPHONE_16",
+    device_type = "iPhone 16",
+    os_version = versions.minimum_ios_version,
+)
+
 ios_unit_test(
     name = "ModelsTests",
     minimum_os_version = versions.minimum_ios_version,
     visibility = ["//modules:default_test_visibility"],
     deps = [":ModelsTestsLib"],
+    runner = "IPHONE_16",
 )

--- a/tools/shared.bzl
+++ b/tools/shared.bzl
@@ -5,5 +5,5 @@ app_info = struct(
 )
 
 versions = struct(
-    minimum_ios_version = "16.0",
+    minimum_ios_version = "18.0",
 )

--- a/tools/shared.bzl
+++ b/tools/shared.bzl
@@ -7,3 +7,5 @@ app_info = struct(
 versions = struct(
     minimum_ios_version = "18.0",
 )
+
+default_test_runner = Label("@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner")


### PR DESCRIPTION
Added `ios_test_runner` to all unit tests, and updated the documentation to provide debugging steps if tests fail due to a device/version mismatch.